### PR TITLE
デプロイ方式を gh-pages ブランチ push 方式に変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,17 +5,18 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# gh-pages ブランチへ push する方式でデプロイする。
+# actions/deploy-pages 方式は Pages 未有効のリポジトリで GITHUB_TOKEN から
+# サイトを作成できず失敗するため、Pages が自動有効化される gh-pages 方式を採用。
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pages
   cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -33,24 +34,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          # リポジトリで Pages が未有効の場合に自動で有効化する
-          enablement: true
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ npm run preview
 ## GitHub Pages へのデプロイ
 
 `main` ブランチへ push すると、GitHub Actions ワークフロー(`.github/workflows/deploy.yml`)が
-`npm ci` → `npm run build` → GitHub Pages へのデプロイまで自動で行います。
+`npm ci` → `npm run build` → `gh-pages` ブランチへの push まで自動で行い、
+GitHub Pages(Source: `gh-pages` ブランチ)として公開されます。
 
-初回のみ、リポジトリの Settings → Pages で、Source を **GitHub Actions** に設定してください。
+公開 URL: https://trajanme.github.io/zoo-map/
 
 `vite.config.js` の `base` は、このリポジトリ名 `zoo-map` に合わせて `'/zoo-map/'` に設定済みです。
 別リポジトリ名で公開する場合は、`vite.config.js` の `base` を実際のリポジトリ名に書き換えてください。


### PR DESCRIPTION
## 概要

初回デプロイ(run #1)で `actions/configure-pages` の自動有効化が
`Resource not accessible by integration` で失敗したため、デプロイ方式を変更します。

## 変更内容

- `.github/workflows/deploy.yml`: `actions/deploy-pages` 方式 → `peaceiris/actions-gh-pages` による `gh-pages` ブランチ push 方式に変更(`gh-pages` ブランチ作成で Pages が自動有効化されるため、リポジトリ設定の手動操作が不要)
- `README.md`: デプロイ手順の記述を更新し、公開 URL(https://trajanme.github.io/zoo-map/)を記載

初回分のビルド成果物は `gh-pages` ブランチとして push 済みで、Pages の自動有効化を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019m4Ldxqy2K9Jp1mdHSFGid

---
_Generated by [Claude Code](https://claude.ai/code/session_019m4Ldxqy2K9Jp1mdHSFGid)_