### PR TITLE
タイル取得ワークフローに push トリガーを追加

### DIFF
--- a/.github/workflows/download-tiles.yml
+++ b/.github/workflows/download-tiles.yml
@@ -2,6 +2,13 @@ name: Download map tiles and OSM reference data
 
 on:
   workflow_dispatch:
+  # workflow_dispatch を API から起動する権限がない環境向け:
+  # このファイルまたはスクリプトの変更が main に入ったら実行する
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/download-tiles.mjs'
+      - '.github/workflows/download-tiles.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
workflow_dispatch を API から起動する権限がないため、ワークフローファイル/スクリプトの変更が main に入った時点で実行される push トリガーを追加します。この PR のマージ自体がタイル取得の初回実行トリガーになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019m4Ldxqy2K9Jp1mdHSFGid

---
_Generated by [Claude Code](https://claude.ai/code/session_019m4Ldxqy2K9Jp1mdHSFGid)_