### PR TITLE
download-tiles ワークフローの YAML 構文エラーを修正

### DIFF
--- a/.github/workflows/download-tiles.yml
+++ b/.github/workflows/download-tiles.yml
@@ -36,8 +36,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Add bundled GSI map tiles and OSM reference data
-
-出典: 地理院タイル(国土地理院) / © OpenStreetMap contributors"
+            git commit -m "Add bundled GSI map tiles and OSM reference data" -m "出典: 地理院タイル(国土地理院) / © OpenStreetMap contributors"
             git push
           fi


### PR DESCRIPTION
`run:` ブロック内のコミットメッセージの改行がインデントなしでリテラルブロックを壊しており、ワークフローが YAML として解析できず全実行が 0 秒で startup 失敗していました。メッセージを `-m` 2つに分けて1行化して修正します。マージ(=このファイルの main への push)が再実行トリガーになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019m4Ldxqy2K9Jp1mdHSFGid

---
_Generated by [Claude Code](https://claude.ai/code/session_019m4Ldxqy2K9Jp1mdHSFGid)_